### PR TITLE
feat: Add add_check step option

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -40,16 +40,16 @@ const @"import(cli.zon)" = .{
             .description = "Output directory path.",
         },
     },
-    .flags = .{
-        .{
-            .long = "add-doc",
-            .description = "Add documentation to exe or lib (add doc step, add CD workflow).",
-        },
-        .{
-            .long = "add-cov",
-            .description = "Add code coverage to exe or lib (add cov step, edit CI workflow, edit .gitignore).",
-        },
-    },
+    .flags = .{ .{
+        .long = "add-doc",
+        .description = "Add documentation to exe or lib (add doc step, add CD workflow).",
+    }, .{
+        .long = "add-cov",
+        .description = "Add code coverage to exe or lib (add cov step, edit CI workflow, edit .gitignore).",
+    }, .{
+        .long = "add-check",
+        .description = "Add compiler Check step to exe or lib",
+    } },
     .positionals = .{
         .{
             .meta = .PCKG_NAME,
@@ -95,6 +95,7 @@ pub fn main() !void {
 
     const add_doc = args.flags.@"add-doc";
     const add_cov = args.flags.@"add-cov";
+    const add_check = args.flags.@"add-check";
 
     const pckg_name = args.positionals.PCKG_NAME;
     const pckg_desc = args.positionals.PCKG_DESC;
@@ -107,8 +108,8 @@ pub fn main() !void {
 
     switch (codebase) {
         .exe, .lib => {},
-        .bld, .app => if (add_doc or add_cov) {
-            @panic("Options add-doc and add-cov are unavailable for bld and app codebases!");
+        .bld, .app => if (add_doc or add_cov or add_check) {
+            @panic("Options add-doc, add-cov and add_check, are unavailable for bld and app codebases!");
         },
     }
 
@@ -127,6 +128,7 @@ pub fn main() !void {
         out_dir_path,
         add_doc,
         add_cov,
+        add_check,
         zig_version,
     );
 }

--- a/src/templates/exe/build.zig
+++ b/src/templates/exe/build.zig
@@ -80,7 +80,7 @@ $c
     });
     fmt_step.dependOn(&fmt.step);
     install_step.dependOn(fmt_step);
-
+$s
     // Binary release
     const release = b.step("release", "Install and archive release binaries");
 

--- a/src/templates/lib/build.zig
+++ b/src/templates/lib/build.zig
@@ -54,7 +54,7 @@ $d
     }
 
     install_step.dependOn(examples_step);
-
+$s
     // Test suite
     const tests_step = b.step("test", "Run test suite");
 


### PR DESCRIPTION
This allows users to add a static compile-time checks, as suggested by [ZLS](https://zigtools.org/zls/guides/build-on-save/). I find myself adding this step to all my projects.